### PR TITLE
Modernize rally results site

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,26 +6,30 @@
   <title>Shitbox Shakedown</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.datatables.net/1.13.7/css/dataTables.bootstrap5.min.css" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="d-flex flex-column min-vh-100">
   <header class="navbar navbar-expand-lg navbar-dark bg-dark border-bottom border-danger">
-    <div class="container">
-      <a class="navbar-brand d-flex align-items-center" href="#">
-        <img src="logo.png" alt="Shitbox Shakedown Logo" id="logo" class="me-2">
+    <div class="container position-relative">
+      <a class="navbar-brand d-flex flex-column align-items-center mx-auto text-center" href="#">
+        <img src="logo.png" alt="Shitbox Shakedown Logo" id="logo" class="mb-1">
         <span>Shitbox Shakedown</span>
       </a>
-      <button id="theme-toggle" class="btn btn-danger ms-auto" aria-label="Toggle color theme">Light Mode</button>
+      <button id="theme-toggle" class="btn btn-danger position-absolute end-0 top-50 translate-middle-y" aria-label="Toggle color theme">Light Mode</button>
     </div>
   </header>
+  <section class="hero text-center text-white py-5">
+    <div class="container">
+      <h1 class="display-4 fw-bold">Shitbox Shakedown Rally League</h1>
+      <p class="lead">Official Leaderboard</p>
+    </div>
+  </section>
   <main class="flex-grow-1 py-4">
     <div class="container text-center">
       <h2 class="mb-4">Round 1 Results <small class="text-muted">21JUN2025</small></h2>
-      <div class="mb-3">
-        <input type="text" id="search" class="form-control" placeholder="Filter by driver...">
-      </div>
       <div id="results-table" class="table-responsive">Loading results...</div>
     </div>
   </main>
@@ -34,7 +38,10 @@
       <p class="mb-0">© 2025 Shitbox Shakedown. Built with blood, duct tape, and HTML.</p>
     </div>
   </footer>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.7/js/dataTables.bootstrap5.min.js"></script>
   <script src="js/render-results.js"></script>
   <script src="js/site.js"></script>
 </body>

--- a/js/render-results.js
+++ b/js/render-results.js
@@ -1,28 +1,33 @@
 fetch('results/round1.csv')
   .then(response => response.text())
   .then(csv => {
-    const rows = csv.trim().split('\n').map(row => row.split(','));
+    const rows = csv.trim().split('\n').map(r => r.split(','));
     const table = document.createElement('table');
     table.className = 'table table-dark table-striped table-hover';
+    const thead = document.createElement('thead');
+    const tbody = document.createElement('tbody');
 
-    rows.forEach((cells, i) => {
-      const row = document.createElement('tr');
+    rows.forEach((cells, idx) => {
+      const tr = document.createElement('tr');
       cells.forEach(cell => {
-        const el = document.createElement(i === 0 ? 'th' : 'td');
+        const el = document.createElement(idx === 0 ? 'th' : 'td');
         el.textContent = cell;
-        row.appendChild(el);
+        tr.appendChild(el);
       });
-      table.appendChild(row);
+      if (idx === 0) thead.appendChild(tr); else tbody.appendChild(tr);
     });
+    table.appendChild(thead);
+    table.appendChild(tbody);
 
     const container = document.getElementById('results-table');
     container.innerHTML = '';
     container.appendChild(table);
-    if (window.attachTableSorting) {
-      window.attachTableSorting(table);
-    }
-    if (window.attachSearchFilter) {
-      window.attachSearchFilter(table);
+    if (window.jQuery && jQuery.fn.dataTable) {
+      $(table).DataTable({
+        paging: false,
+        info: false,
+        searching: true
+      });
     }
   })
   .catch(err => {

--- a/js/site.js
+++ b/js/site.js
@@ -18,44 +18,4 @@ function initThemeToggle() {
   });
 }
 
-function attachTableSorting(table) {
-  const headers = table.querySelectorAll('th');
-  headers.forEach((th, index) => {
-    th.style.cursor = 'pointer';
-    th.addEventListener('click', () => {
-      const rows = Array.from(table.querySelectorAll('tr')).slice(1);
-      const asc = th.dataset.asc !== 'true';
-      rows.sort((a, b) => {
-        const aText = a.children[index].textContent;
-        const bText = b.children[index].textContent;
-        const aNum = parseFloat(aText);
-        const bNum = parseFloat(bText);
-        if (!isNaN(aNum) && !isNaN(bNum)) {
-          return asc ? aNum - bNum : bNum - aNum;
-        }
-        return asc ? aText.localeCompare(bText) : bText.localeCompare(aText);
-      });
-      th.dataset.asc = asc;
-      rows.forEach(r => table.appendChild(r));
-    });
-  });
-}
-
-function attachSearchFilter(table) {
-  const input = document.getElementById('search');
-  if (!input) return;
-  input.addEventListener('input', () => {
-    const query = input.value.trim().toLowerCase();
-    const rows = table.querySelectorAll('tr');
-    rows.forEach((row, idx) => {
-      if (idx === 0) return; // skip header
-      const driver = row.children[1].textContent.toLowerCase();
-      row.style.display = driver.includes(query) ? '' : 'none';
-    });
-  });
-}
-
-window.attachTableSorting = attachTableSorting;
-window.attachSearchFilter = attachSearchFilter;
-
 document.addEventListener('DOMContentLoaded', initThemeToggle);

--- a/style.css
+++ b/style.css
@@ -1,9 +1,23 @@
 body {
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Poppins', 'Roboto', sans-serif;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(230,57,70,0.85), rgba(29,53,87,0.85)), url('logo.png') center/cover;
+  color: #fff;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.6);
+}
+.hero h1 {
+  font-size: 3rem;
+}
+.hero p {
+  font-size: 1.25rem;
 }
 
 #logo {
-  height: 60px;
+  height: 90px;
+  display: block;
+  margin: 0 auto;
 }
 
 /* Theme colors */
@@ -28,4 +42,14 @@ footer {
 /* Table styling */
 #results-table table {
   width: 100%;
+}
+
+/* DataTables tweaks */
+.dataTables_wrapper .dataTables_filter label {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+.dataTables_wrapper .dataTables_filter input {
+  margin-left: 0.5rem;
+  width: 200px;
 }


### PR DESCRIPTION
## Summary
- refresh fonts and add hero section
- use DataTables for sorting/search
- integrate jQuery/DataTables CDN assets
- clean up JS utilities
- fix results table initialization for DataTables
- center brand in navbar and enlarge logo

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860667bd82c83218d6848f5bcfbe5de