### PR TITLE
Enable masonry gallery layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,92 +46,90 @@
           </div>
           <!-- Photo Gallery Start -->
           <div id="photo-gallery" class="mt-5">
-            <div class="row g-3 justify-content-center">
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250620_184843.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250620_184843.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 1"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_075647.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_075647.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 2"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_111442.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_111442.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 3"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_123949.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_123949.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 4"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_130800.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_130800.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 5"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_130812.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_130812.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 6"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_131633.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_131633.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 7"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_132041.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_132041.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 8"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_134653.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_134653.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 9"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_135541.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_135541.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 10"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_135603.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_135603.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 11"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_140043.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_140043.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 12"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_140833.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_140833.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 13"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_140839.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_140839.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 14"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_140840.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_140840.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 15"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_141304.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_141304.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 16"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_154637.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_154637.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 17"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_174035.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_174035.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 18"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_174259.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_174259.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 19"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_174304.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_174304.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 20"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_174305.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_174305.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 21"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/20250621_180150.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/20250621_180150.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 22"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/file_000000000f5061f797258c39b2f2f82c.png" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/file_000000000f5061f797258c39b2f2f82c.png" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 23"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/file_000000000f5061f797258c39b2f2f82c0001.png" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/file_000000000f5061f797258c39b2f2f82c0001.png" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 24"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/IMG_20250623_152455.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/IMG_20250623_152455.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 25"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/IMG_20250623_214249.jpg" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/IMG_20250623_214249.jpg" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 26"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/Screenshot_20250623-110727.png" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/Screenshot_20250623-110727.png" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 27"></a>
               </div>
-              <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+              <div class="gallery-item">
                 <a href="photo_reel/Screenshot_20250623-110952.png" data-bs-toggle="modal" data-bs-target="#galleryModal"><img src="photo_reel/Screenshot_20250623-110952.png" class="img-fluid rounded shadow-sm gallery-thumb" alt="Race photo 28"></a>
               </div>
-            </div>
           </div>
           <!-- Photo Gallery End -->
         </div>

--- a/style.css
+++ b/style.css
@@ -2,14 +2,39 @@
 #photo-gallery {
   margin-top: 2.5rem;
   margin-bottom: 2.5rem;
+  column-count: 1;
+  column-gap: 1rem;
+}
+
+@media (min-width: 576px) {
+  #photo-gallery {
+    column-count: 2;
+  }
+}
+
+@media (min-width: 768px) {
+  #photo-gallery {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 992px) {
+  #photo-gallery {
+    column-count: 4;
+  }
+}
+
+.gallery-item {
+  break-inside: avoid;
+  margin-bottom: 1rem;
 }
 
 /* Gallery Divider Styles */
 .gallery-divider {
   width: 100%;
   max-width: 900px;
-  margin-left: 0;
-  margin-right: 0;
+  margin-left: auto;
+  margin-right: auto;
   gap: 0.5rem;
   opacity: 0.97;
   display: flex;
@@ -52,8 +77,7 @@
 }
 .gallery-thumb {
   width: 100%;
-  aspect-ratio: 1/1;
-  object-fit: cover;
+  height: auto;
   border-radius: 0.7rem;
   box-shadow: 0 2px 12px #00b4d822, 0 1px 4px #0008;
   transition: transform 0.18s, box-shadow 0.18s, filter 0.18s;


### PR DESCRIPTION
## Summary
- transform gallery markup to masonry layout using CSS columns
- preserve photo aspect ratios and center section divider

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68613ac9c8788321b1d3fef2fb662b0a